### PR TITLE
Fix handleAttribute.emit is not a function for default services

### DIFF
--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -911,7 +911,9 @@ Gatt.prototype.handleWriteRequestOrCommand = function(request) {
               handleAttribute.emit('subscribe', this._mtu - 3, updateValueCallback);
             }
           } else {
-            handleAttribute.emit('unsubscribe');
+            if (handleAttribute.emit) {
+              handleAttribute.emit('unsubscribe');
+            }
           }
 
           result = ATT_ECODE_SUCCESS;


### PR DESCRIPTION
/home/pi/pnppi/node_modules/@abandonware/bleno/lib/hci-socket/gatt.js:914
            handleAttribute.emit('unsubscribe');
                            ^

TypeError: handleAttribute.emit is not a function
    at Gatt.handleWriteRequestOrCommand (/home/pi/pnppi/node_modules/@abandonware/bleno/lib/hci-socket/gatt.js:914:29)
    at Gatt.handleRequest (/home/pi/pnppi/node_modules/@abandonware/bleno/lib/hci-socket/gatt.js:344:23)
    at Gatt.onAclStreamData (/home/pi/pnppi/node_modules/@abandonware/bleno/lib/hci-socket/gatt.js:274:8)
    at AclStream.emit (events.js:203:15)
    at AclStream.push (/home/pi/pnppi/node_modules/@abandonware/bleno/lib/hci-socket/acl-stream.js:26:10)
    at BlenoBindings.onAclDataPkt (/home/pi/pnppi/node_modules/@abandonware/bleno/lib/hci-socket/bindings.js:194:21)
    at Hci.emit (events.js:198:13)
    at Hci.onSocketData (/home/pi/pnppi/node_modules/@abandonware/bleno/lib/hci-socket/hci.js:588:14)
    at BluetoothHciSocket.emit (events.js:198:13)