### PR TITLE
Fix insufficient permission/capability check.

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -622,7 +622,7 @@ Hci.prototype.onSocketData = function(data) {
 Hci.prototype.onSocketError = function(error) {
   debug('onSocketError: ' + error.message);
 
-  if (error.message === 'Operation not permitted') {
+  if (error.code === 'EPERM') {
     this.emit('stateChange', 'unauthorized');
   } else if (error.message === 'Network is down') {
     // no-op


### PR DESCRIPTION
Check the error code instead of the error message as the message is not
guaranteed to be stable.