### PR TITLE
fixed cross link bleno<->noble in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A Node.js module for implementing BLE (Bluetooth Low Energy) peripherals.
 
-Need a BLE central module? See [noble](https://github.com/sandeepmistry/noble).
+Need a BLE central module? See [noble](https://github.com/abandonware/noble).
 
 __Note:__ macOS / Mac OS X, Linux, FreeBSD and Windows are currently the only supported OSes.
 


### PR DESCRIPTION
Fixed cross-link between noble and bleno repositories inside abandonware group.