### PR TITLE
Fix abandonware@bleno issue-51 by skipping 2902 peripheral declared characteristic descriptor

### DIFF
--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -218,6 +218,15 @@ class Gatt  extends EventEmitter {
 
         for (let k = 0; k < characteristic.descriptors.length; k++) {
           const descriptor = characteristic.descriptors[k];
+          
+          //https://github.com/abandonware/bleno/issues/51
+          //above, if the characteristic defines notify, the 2902 characteristic descriptor is added automatically
+          //if the peripheral also declares this, we don't want to add it again
+          //flags (properties, secure etc) above are better defined
+          if(descriptor.uuid == '2902')
+          {
+            continue;
+          }
 
           handle++;
           const descriptorHandle = handle;


### PR DESCRIPTION
See: https://github.com/abandonware/bleno/issues/51

This fixes the issue by skipping 0x2902 characteristic descriptor when it is defined on the peripheral