### PR TITLE
ci: github: Remove node-14

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-latest, macos-latest, windows-2019]
-        node: [14, 16, 18]
+        node: [16, 18]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-latest, macos-latest, windows-2019]
+        os: [ubuntu-20.04, ubuntu-latest, windows-2019]
         node: [16, 18]
 
     steps:


### PR DESCRIPTION
As it is no more supported by GH:

https://github.com/abandonware/bleno/actions/runs/12851127399?pr=54