### PR TITLE
Update package.json to 0.6.2 for a new npm release

### DIFF
--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -39,7 +39,7 @@ const GATT_INCLUDE_UUID               = 0x2802;
 const GATT_CHARAC_UUID                = 0x2803;
 
 const GATT_CLIENT_CHARAC_CFG_UUID     = 0x2902;
-const GATT_CLIENT_CHARAC_CFG_UUID_S   = '2902'
+const GATT_CLIENT_CHARAC_CFG_UUID_S   = '2902';
 const GATT_SERVER_CHARAC_CFG_UUID     = 0x2903;
 
 const ATT_ECODE_SUCCESS               = 0x00;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@abandonware/bleno",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@abandonware/bleno",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "os": [
         "darwin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abandonware/bleno",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A Node.js module for implementing BLE (Bluetooth Low Energy) peripherals",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
With the previous [fix ](https://github.com/abandonware/bleno/pull/54)to support linux kernel 6.9, we need to bump the version so the npm package reflects the change.